### PR TITLE
applied compiler suggestion on a Bencher lifetime

### DIFF
--- a/src/bencher.rs
+++ b/src/bencher.rs
@@ -59,7 +59,7 @@ fn filter_iterator(result: &RunResults) -> impl std::iter::Iterator<Item = (Stri
 }
 
 /// Creates an iterator for the point results with the appropriate map
-fn points_iterator(result: &RunResults) -> impl std::iter::Iterator<Item = (String, Bencher)> {
+fn points_iterator(result: &RunResults) -> impl std::iter::Iterator<Item = (String, Bencher<'_>)> {
     result.point_results.iter().map(|(key, points)| {
         let name = if points.no_unit_conversion {
             "Data"


### PR DESCRIPTION
There is a warning when running the app,
compiler suggests adding explicit lifetime syntax

I am not sure if I should just ignore it, or to apply it, so here is the RP draft for discussion
 
```bash
cargo run -- --trace-file /tmp/app.ftrace
warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/bencher.rs:62:28
   |
62 | fn points_iterator(result: &RunResults) -> impl std::iter::Iterator<Item = (String, Bencher)> {
   |                            ^^^^^^^^^^^ the lifetime is elided here                  ------- the same lifetime is hidden here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
62 | fn points_iterator(result: &RunResults) -> impl std::iter::Iterator<Item = (String, Bencher<'_>)> {
   |                                                                                            ++++

warning: `hitrace-bench` (bin "hitrace-bench") generated 1 warning
```