### PR TITLE
more regex for new ftrace

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,52 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug executable 'hitrace-bench'",
+            "type": "lldb",
+            "request": "launch",
+            "cargo": {
+                "args": [
+                    "run",
+                    "--bin=hitrace-bench"
+                ]
+            },
+            "args": []
+        },
+        {
+            "name": "Debug runs.json",
+            "type": "lldb",
+            "request": "launch",
+            "cargo": {
+                "args": [
+                    "run",
+                    "--bin=hitrace-bench"
+                ]
+            },
+            "args": ["-r", "runs2.json"]
+        },
+        {
+            "name": "Debug tmp file",
+            "type": "lldb",
+            "request": "launch",
+            "cargo": {
+                "args": ["run", "--bin=hitrace-bench"]
+            },
+            "args": ["--trace-file", "/tmp/app.ftrace"]
+        },
+        {
+            "name": "Debug unit tests in executable 'hitrace-bench'",
+            "type": "lldb",
+            "request": "launch",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--bin=hitrace-bench"
+                ]
+            }
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +162,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -282,6 +308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +445,7 @@ name = "hitrace-bench"
 version = "0.9.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "ctrlc",
  "env_logger",
@@ -675,6 +708,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -997,6 +1057,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1176,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.100"
+assert_cmd = "2.1.2"
 clap = { version = "4.5.53", features = ["derive"] }
 ctrlc = "3.5.1"
 env_logger = "0.11.8"

--- a/runs.json
+++ b/runs.json
@@ -5,7 +5,7 @@
     {
         "run_args": {
             "url": "https://www.google.com", // the url to test
-            "tries": 5 // How many repeated tries we should have, we show the min,max,avg in the output
+            "tries": 1 // How many repeated tries we should have, we show the min,max,avg in the output
             //"trace_buffer": 524288,   // trace_buffer size of hitrace
             //"sleep": 10,  // how long should we wait for servo to load the page
             //"commands": ["--ps=--tracing-filter", "info"] // arbitrary additional arguments
@@ -55,7 +55,7 @@
     {
         "run_args": {
             "url": "https://www.servo.org",
-            "tries": 5
+            "tries": 1
         },
         "filters": [
             {
@@ -89,6 +89,11 @@
                 "name": "resident-smaps",
                 "match_str": "resident-according-to-smaps",
                 "combined": true
+            },
+            {
+                "name": "largesetcontentfullpaint",
+                "match_str": "LargestContentfulPaint",
+                "combined": true
             }
         ]
     },
@@ -96,7 +101,7 @@
         "run_args": {
             "bencher": true,
             "url": "file:///parse_from_string.html",
-            "tries": 5
+            "tries": 1
         },
         "filters": [
         ],

--- a/src/device.rs
+++ b/src/device.rs
@@ -127,6 +127,7 @@ pub(crate) fn exec_hdc_commands(run_args: &RunArgs, is_rooted: bool) -> Result<P
         "js_disable_jit=true",
         "--ps=--tracing-filter",
         "trace",
+        "--psn=--pref=largest_contentful_paint_enabled=true",
     ];
     if let Some(ref v) = run_args.commands {
         let mut v = v.iter().map(|s| s.as_str()).collect();

--- a/testdata/bench_v5_1_1.json
+++ b/testdata/bench_v5_1_1.json
@@ -1,0 +1,128 @@
+{
+  "E2E/https://servo.org/Resident": {
+    "Memory": {
+      "value": 403623936.0,
+      "lower_value": 403623936.0,
+      "upper_value": 403623936.0
+    }
+  },
+  "E2E/Surface->LoadStart": {
+    "Latency": {
+      "value": 753340000.0,
+      "lower_value": 753340000.0,
+      "upper_value": 753340000.0
+    }
+  },
+  "E2E/https://servo.org/LayoutThread/box-tree": {
+    "Memory": {
+      "value": 84708496.0,
+      "lower_value": 84708496.0,
+      "upper_value": 84708496.0
+    }
+  },
+  "E2E/https://servo.org/LayoutThread/fragment-tree": {
+    "Memory": {
+      "value": 112.0,
+      "lower_value": 112.0,
+      "upper_value": 112.0
+    }
+  },
+  "E2E/https://servo.org/LayoutThread/font-context": {
+    "Memory": {
+      "value": 396720.0,
+      "lower_value": 396720.0,
+      "upper_value": 396720.0
+    }
+  },
+  "E2E/https://servo.org/JS/malloc-heap": {
+    "Memory": {
+      "value": 5483027.0,
+      "lower_value": 5483027.0,
+      "upper_value": 5483027.0
+    }
+  },
+  "E2E/https://servo.org/image-cache": {
+    "Memory": {
+      "value": 3718280.0,
+      "lower_value": 3718280.0,
+      "upper_value": 3718280.0
+    }
+  },
+  "E2E/https://servo.org/JS/gc-heap/admin": {
+    "Memory": {
+      "value": 27840.0,
+      "lower_value": 27840.0,
+      "upper_value": 27840.0
+    }
+  },
+  "E2E/https://servo.org/LayoutThread/display-list": {
+    "Memory": {
+      "value": 0.0,
+      "lower_value": 0.0,
+      "upper_value": 0.0
+    }
+  },
+  "E2E/https://servo.org/image-cache/fontdb": {
+    "Memory": {
+      "value": 0.0,
+      "lower_value": 0.0,
+      "upper_value": 0.0
+    }
+  },
+  "E2E/https://servo.org/LayoutThread/stacking-context-tree": {
+    "Memory": {
+      "value": 167760.0,
+      "lower_value": 167760.0,
+      "upper_value": 167760.0
+    }
+  },
+  "E2E/https://servo.org/JS/gc-heap/decommitted": {
+    "Memory": {
+      "value": 339968.0,
+      "lower_value": 339968.0,
+      "upper_value": 339968.0
+    }
+  },
+  "E2E/https://servo.org/LayoutThread/stylist": {
+    "Memory": {
+      "value": 498871.0,
+      "lower_value": 498871.0,
+      "upper_value": 498871.0
+    }
+  },
+  "E2E/Load->Compl": {
+    "Latency": {
+      "value": 2074614000.0,
+      "lower_value": 2074614000.0,
+      "upper_value": 2074614000.0
+    }
+  },
+  "E2E/https://servo.org/JS/gc-heap/unused": {
+    "Memory": {
+      "value": 139248.0,
+      "lower_value": 139248.0,
+      "upper_value": 139248.0
+    }
+  },
+  "E2E/https://servo.org/resident-smaps": {
+    "Memory": {
+      "value": 404639744.0,
+      "lower_value": 404639744.0,
+      "upper_value": 404639744.0
+    }
+  },
+  "E2E/https://servo.org/JS/non-heap": {
+    "Memory": {
+      "value": 262144.0,
+      "lower_value": 262144.0,
+      "upper_value": 262144.0
+    }
+  },
+  "E2E/https://servo.org/JS/gc-heap/used": {
+    "Memory": {
+      "value": 541520.0,
+      "lower_value": 541520.0,
+      "upper_value": 541520.0
+    }
+  }
+}

--- a/testdata/v5.1.1.ftrace
+++ b/testdata/v5.1.1.ftrace
@@ -1,0 +1,68 @@
+# tracer: nop
+#                                          _-----=> irqs-off
+#                                         / _----=> need-resched
+#                                        | / _---=> hardirq/softirq
+#                                        || / _--=> preempt-depth
+#                                        ||| /     delay
+#           TASK-PID       TGID    CPU#  ||||   TIMESTAMP  FUNCTION
+#              | |           |       |   ||||      |         |
+           <...>-57783   (-------) [010] .... 510487.404088: tracing_mark_write: B|57783|H:on_surface_created_cb|M62
+           <...>-57910   (-------) [008] .... 510488.157428: tracing_mark_write: B|57783|H:load status changed HeadParsed|M62
+           <...>-57910   (-------) [010] .... 510490.232042: tracing_mark_write: B|57783|H:PageLoadEndedPrompt|M62
+           <...>-58089   (-------) [010] .... 510490.313831: tracing_mark_write: C|57783|H:servo_memory_profiling:vsize|45766221824|M62
+           <...>-58089   (-------) [010] .... 510490.313834: tracing_mark_write: C|57783|H:servo_memory_profiling:resident|403623936|M62
+           <...>-58089   (-------) [010] .... 510490.313836: tracing_mark_write: C|57783|H:servo_memory_profiling:pss|282854|M62
+           <...>-58089   (-------) [010] .... 510490.313838: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps/[anon:ArkTS Code:386504056832] (rw-p)|1290240|M62
+           <...>-58089   (-------) [010] .... 510490.313840: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//vendor/lib64/passthrough/libhvgr_v200.so (r-xp)|1646592|M62
+           <...>-58089   (-------) [010] .... 510490.313843: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//data/app/el1/bundle/public/com.huawei.hmos.arkwebcore/libs/arm64/libarkweb_engine.so (rw-p)|581632|M62
+           <...>-58089   (-------) [010] .... 510490.313844: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib64/platformsdk/libark_jsruntime.so (r-xp)|2072576|M62
+           <...>-58089   (-------) [010] .... 510490.313845: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps/other|65134592|M62
+           <...>-58089   (-------) [010] .... 510490.313847: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps/[anon:libace_compatible.z.so.bss] (rw-p)|700416|M62
+           <...>-58089   (-------) [010] .... 510490.313848: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps/[anon:libmedialibrary_nutils.z.so.bss] (rw-p)|741376|M62
+           <...>-58089   (-------) [010] .... 510490.313849: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib64/libark_llvmcodegen.so (r--p)|999424|M62
+           <...>-58089   (-------) [010] .... 510490.313851: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//data/app/el1/bundle/public/com.huawei.hmos.arkwebcore/libs/arm64/libarkweb_engine.so (r--p)|8773632|M62
+           <...>-58089   (-------) [010] .... 510490.313852: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib/ld-musl-aarch64.so.1 (r-xp)|1327104|M62
+           <...>-58089   (-------) [010] .... 510490.313853: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps/[anon:native_heap:jemalloc] (rw-p)|255057920|M62
+           <...>-58089   (-------) [010] .... 510490.313854: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//data/storage/el1/bundle/libs/arm64/libservoshell.so (r--p)|15114240|M62
+           <...>-58089   (-------) [010] .... 510490.313855: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib64/ndk/libffrt.so (r-xp)|602112|M62
+           <...>-58089   (-------) [010] .... 510490.313856: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib64/platformsdk/libace_compatible.z.so (r-xp)|6975488|M62
+           <...>-58089   (-------) [010] .... 510490.313857: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib64/module/arkcompiler/stub.an (r-xp)|589824|M62
+           <...>-58089   (-------) [010] .... 510490.313859: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//data/storage/el1/bundle/libs/arm64/libservoshell.so (r-xp)|26406912|M62
+           <...>-58089   (-------) [010] .... 510490.313860: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//data/storage/el1/bundle/libs/arm64/libservoshell.so (rw-p)|593920|M62
+           <...>-58089   (-------) [010] .... 510490.313861: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib64/platformsdk/libappkit_native.z.so (r-xp)|860160|M62
+           <...>-58089   (-------) [010] .... 510490.313862: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/fonts/NotoSansCJK-Regular.ttc (r--p)|663552|M62
+           <...>-58089   (-------) [010] .... 510490.313863: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps/[anon:js-gc-heap] (rw-p)|729088|M62
+           <...>-58089   (-------) [010] .... 510490.313864: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//vendor/lib64/passthrough/indirect/libbishenggpucompiler_v200.so.15 (r--p)|4308992|M62
+           <...>-58089   (-------) [010] .... 510490.313865: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib64/libskia_canvaskit.z.so (r-xp)|1101824|M62
+           <...>-58089   (-------) [010] .... 510490.313867: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib64/librender_service_client.z.so (r-xp)|602112|M62
+           <...>-58089   (-------) [010] .... 510490.313868: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps/[anon:native_heap:jemalloc meta] (rw-p)|1122304|M62
+           <...>-58089   (-------) [010] .... 510490.313869: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib64/libwm.z.so (r-xp)|610304|M62
+           <...>-58089   (-------) [010] .... 510490.313870: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps//system/lib64/platformsdk/libace_compatible.z.so (r--p)|5423104|M62
+           <...>-58089   (-------) [010] .... 510490.313872: tracing_mark_write: C|57783|H:servo_memory_profiling:resident-according-to-smaps/[anon:libark_jsoptimizer.so.bss] (rw-p)|610304|M62
+           <...>-58089   (-------) [010] .... 510490.313874: tracing_mark_write: C|57783|H:servo_memory_profiling:webrender/fonts|81920|M62
+           <...>-58089   (-------) [010] .... 510490.313875: tracing_mark_write: C|57783|H:servo_memory_profiling:webrender/images|90554368|M62
+           <...>-58089   (-------) [010] .... 510490.313876: tracing_mark_write: C|57783|H:servo_memory_profiling:webrender/display-list|116416|M62
+           <...>-58089   (-------) [010] .... 510490.313877: tracing_mark_write: C|57783|H:servo_memory_profiling:paint/scroll-tree|1288|M62
+           <...>-58089   (-------) [010] .... 510490.313879: tracing_mark_write: C|57783|H:servo_memory_profiling:system-fonts|29944|M62
+           <...>-58089   (-------) [010] .... 510490.313880: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/layout-thread/display-list|0|M62
+           <...>-58089   (-------) [010] .... 510490.313881: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/layout-thread/stylist|498871|M62
+           <...>-58089   (-------) [010] .... 510490.313882: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/layout-thread/font-context|396720|M62
+           <...>-58089   (-------) [010] .... 510490.313883: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/layout-thread/box-tree|84708496|M62
+           <...>-58089   (-------) [010] .... 510490.313884: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/layout-thread/fragment-tree|112|M62
+           <...>-58089   (-------) [010] .... 510490.313885: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/layout-thread/stacking-context-tree|167760|M62
+           <...>-58089   (-------) [010] .... 510490.313887: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/image-cache|3718280|M62
+           <...>-58089   (-------) [010] .... 510490.313888: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/image-cache/fontdb|0|M62
+           <...>-58089   (-------) [010] .... 510490.313889: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/js/gc-heap/used|541520|M62
+           <...>-58089   (-------) [010] .... 510490.313890: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/js/gc-heap/unused|139248|M62
+           <...>-58089   (-------) [010] .... 510490.313891: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/js/gc-heap/admin|27840|M62
+           <...>-58089   (-------) [010] .... 510490.313892: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/js/gc-heap/decommitted|339968|M62
+           <...>-58089   (-------) [010] .... 510490.313893: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/js/malloc-heap|5483027|M62
+           <...>-58089   (-------) [010] .... 510490.313894: tracing_mark_write: C|57783|H:servo_memory_profiling:url(https://servo.org/)/js/non-heap|262144|M62
+           <...>-58089   (-------) [010] .... 510490.313895: tracing_mark_write: C|57783|H:servo_memory_profiling:storage/local|0|M62
+           <...>-58089   (-------) [010] .... 510490.313897: tracing_mark_write: C|57783|H:servo_memory_profiling:storage/session|0|M62
+           <...>-58089   (-------) [010] .... 510490.313898: tracing_mark_write: C|57783|H:servo_memory_profiling:memory-cache/public|2253616|M62
+           <...>-58089   (-------) [010] .... 510490.313899: tracing_mark_write: C|57783|H:servo_memory_profiling:hsts-list/public|552|M62
+           <...>-58089   (-------) [010] .... 510490.313900: tracing_mark_write: C|57783|H:servo_memory_profiling:memory-cache/private|0|M62
+           <...>-58089   (-------) [010] .... 510490.313901: tracing_mark_write: C|57783|H:servo_memory_profiling:hsts-list/private|0|M62
+           <...>-58089   (-------) [010] .... 510490.313902: tracing_mark_write: C|57783|H:servo_memory_profiling:hsts-preload-list|2097152|M62
+           <...>-58089   (-------) [010] .... 510490.313903: tracing_mark_write: C|57783|H:servo_memory_profiling:public-suffix-list|602536|M62

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,23 @@
+use assert_cmd::cargo::*;
+use serde_json::Value;
+use std::fs;
+
+#[test]
+fn parses_file_and_outputs_expected_json() -> Result<(), Box<dyn std::error::Error>> {
+    let input_path = "./testdata/v5.1.1.ftrace";
+    let expected_json = fs::read_to_string("testdata/bench_v5_1_1.json")?;
+
+    let mut cmd = cargo_bin_cmd!("hitrace-bench");
+    let assert = cmd
+        .arg("--bencher")
+        .arg("--trace-file")
+        .arg(input_path)
+        .assert();
+
+    let output = assert.success().get_output().stdout.clone();
+    let actual_json: Value = serde_json::from_slice(&output)?;
+    let expected_json: Value = serde_json::from_str(&expected_json)?;
+
+    assert_eq!(actual_json, expected_json);
+    Ok(())
+}


### PR DESCRIPTION
* More regex options to cover both old and new format of the ftrace
* added them debug run configs
* I have additionally added a test to test the current ftrace format (with its current sample trace and sample output (is it ok to have them?)
* and also added `--psn=--pref=largest_contentful_paint_enabled=true` to the default run command (this could be specified in the run.json instead, but I see it ok being kinda global).
