### PR TITLE
added LCP pref

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -127,6 +127,7 @@ pub(crate) fn exec_hdc_commands(run_args: &RunArgs, is_rooted: bool) -> Result<P
         "js_disable_jit=true",
         "--ps=--tracing-filter",
         "trace",
+        "--psn=--pref=largest_contentful_paint_enabled=true",
     ];
     if let Some(ref v) = run_args.commands {
         let mut v = v.iter().map(|s| s.as_str()).collect();


### PR DESCRIPTION
Is it a good idea to have LCP pref being "global" or is it better to pass it via "run.json"?
I guess it is easier for me to have it "global" as PR suggests, so I can run `cargo run` and get LCP without input json