### PR TITLE
Make the CLI generic with app-arg passthrough

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -4,6 +4,11 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 use serde::Deserialize;
 
+/// Default ability URI / homepage used by the servo example.
+pub(crate) const SERVO_DEFAULT_URL: &str = "https://servo.org";
+/// Default bundle used by the servo example.
+pub(crate) const SERVO_DEFAULT_BUNDLE: &str = "org.servo.servo";
+
 #[derive(Clone, Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub(crate) struct Args {
@@ -37,6 +42,13 @@ pub(crate) struct Args {
 }
 
 impl Args {
+    pub(crate) fn run_args(&self) -> Option<&RunArgs> {
+        match &self.per_run {
+            Some(PerRun::PerRun(run_args)) => Some(run_args),
+            None => None,
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn test_default(path: PathBuf) -> Args {
         Args {
@@ -58,22 +70,23 @@ enum PerRun {
 
 impl TryFrom<&Args> for RunArgs {
     fn try_from(value: &Args) -> Result<Self, Self::Error> {
-        match &value.per_run {
-            Some(PerRun::PerRun(run_args)) => Ok(run_args.to_owned()),
-            None => Err(anyhow!("Could not convert")),
-        }
+        value
+            .run_args()
+            .cloned()
+            .ok_or_else(|| anyhow!("Could not convert"))
     }
 
     type Error = anyhow::Error;
 }
 
-#[derive(Clone, Parser, Debug, Deserialize)]
+#[derive(Clone, Parser, Debug, Deserialize, PartialEq, Eq)]
 #[command(version, about, long_about = None)]
-/// Run servo on an open harmony device and collect timing information
+/// Run an app on an OpenHarmony device and collect timing information.
+/// Servo remains the default example (homepage, bundle, and launch flags).
 pub(crate) struct RunArgs {
     #[arg(short, long)]
     #[serde(default = "default_all_traces")]
-    /// Show all traces for servo
+    /// Show all collected traces for the app under test
     pub(crate) all_traces: bool,
 
     /// The number of tries we should have to average
@@ -81,10 +94,18 @@ pub(crate) struct RunArgs {
     #[serde(default = "default_tries")]
     pub(crate) tries: usize,
 
-    /// The homepage we try to load
-    #[arg(short, long, default_value_t = String::from("https://servo.org"))]
-    #[serde(default = "default_url")]
-    pub(crate) url: String,
+    /// Optional ability URI passed to `aa start -U`.
+    /// Servo uses this as the homepage. When omitted, servo defaults use
+    /// `https://servo.org`. Pass `--no-servo-defaults` to skip `-U`.
+    #[arg(short, long)]
+    #[serde(default)]
+    pub(crate) url: Option<String>,
+
+    /// Do not apply servo example defaults (homepage URI and servo-specific
+    /// `aa start` flags such as `--ps=--pref`).
+    #[arg(long = "no-servo-defaults", default_value_t = false)]
+    #[serde(default)]
+    pub(crate) no_servo_defaults: bool,
 
     /// Trace Buffer size in KB
     #[arg(short = 't', long, default_value_t = 524288)]
@@ -97,14 +118,24 @@ pub(crate) struct RunArgs {
     pub(crate) sleep: u64,
 
     /// Name of the app bundle to start
-    #[arg(short, long, default_value_t = String::from("org.servo.servo"))]
+    #[arg(short, long, default_value_t = String::from(SERVO_DEFAULT_BUNDLE))]
     #[serde(default = "default_bundle_name")]
     pub(crate) bundle_name: String,
 
-    /// These will be directly given to the hdc shell start command at the end.
-    #[arg(long, trailing_var_arg(true), allow_hyphen_values(true), num_args=0..)]
+    /// Extra arguments forwarded to `aa start` (legacy; prefer `--app-arg` or `--`).
+    #[arg(long, allow_hyphen_values = true, num_args = 1, action = clap::ArgAction::Append)]
     #[serde(default = "default_commands")]
     pub(crate) commands: Option<Vec<String>>,
+
+    /// Extra argument forwarded to the app under test (`aa start`). Repeatable.
+    #[arg(long = "app-arg", allow_hyphen_values = true, action = clap::ArgAction::Append)]
+    #[serde(default)]
+    pub(crate) app_args: Vec<String>,
+
+    /// Extra arguments after `--`, forwarded to the app under test.
+    #[arg(last = true, allow_hyphen_values = true)]
+    #[serde(default)]
+    pub(crate) extra_args: Vec<String>,
 
     /// Use mitmproxy. Automatically start mitmdump and kill it again after the run.
     #[arg(long, default_value_t = false)]
@@ -117,14 +148,75 @@ impl Default for RunArgs {
         Self {
             all_traces: default_all_traces(),
             tries: default_tries(),
-            url: default_url(),
+            url: None,
+            no_servo_defaults: false,
             trace_buffer: default_trace_buffer(),
             sleep: default_sleep(),
             bundle_name: default_bundle_name(),
             commands: default_commands(),
+            app_args: Vec::new(),
+            extra_args: Vec::new(),
             mitmproxy: false,
         }
     }
+}
+
+impl RunArgs {
+    /// Whether servo example defaults should be applied.
+    pub(crate) fn servo_defaults(&self) -> bool {
+        !self.no_servo_defaults
+    }
+
+    /// Ability URI / homepage after applying servo defaults.
+    ///
+    /// An explicit `--url` (including an empty value) wins. Otherwise servo
+    /// defaults supply `https://servo.org`.
+    pub(crate) fn resolved_url(&self) -> Option<&str> {
+        match self.url.as_deref() {
+            Some(url) if url.is_empty() => None,
+            Some(url) => Some(url),
+            None if self.servo_defaults() => Some(SERVO_DEFAULT_URL),
+            None => None,
+        }
+    }
+
+    /// Label used in printed / bencher result names.
+    pub(crate) fn result_label(&self) -> &str {
+        self.resolved_url().unwrap_or(self.bundle_name.as_str())
+    }
+
+    /// App-specific arguments to append to `aa start`, from `--commands`,
+    /// `--app-arg`, and `--`.
+    pub(crate) fn forwarded_app_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(commands) = &self.commands {
+            args.extend(commands.iter().cloned());
+        }
+        args.extend(self.app_args.iter().cloned());
+        args.extend(self.extra_args.iter().cloned());
+        args
+    }
+}
+
+/// Servo-specific flags previously hardcoded into every `aa start` invocation.
+pub(crate) fn servo_default_launch_flags() -> Vec<String> {
+    vec![
+        "--ps=--pref".to_owned(),
+        "js_disable_jit=true".to_owned(),
+        "--ps=--tracing-filter".to_owned(),
+        "trace".to_owned(),
+        "--psn=--pref=largest_contentful_paint_enabled=true".to_owned(),
+    ]
+}
+
+/// Servo-specific mitmproxy prefs appended when `--mitmproxy` is used with
+/// servo defaults.
+pub(crate) fn servo_mitmproxy_launch_flags(proxy_port: &str) -> Vec<String> {
+    vec![
+        format!("--psn=--pref=network_http_proxy_uri=http://127.0.0.1:{proxy_port}"),
+        format!("--psn=--pref=network_https_proxy_uri=http://127.0.0.1:{proxy_port}"),
+        "--psn=--ignore-certificate-errors".to_owned(),
+    ]
 }
 
 // these are for serde
@@ -136,10 +228,6 @@ fn default_tries() -> usize {
     1
 }
 
-fn default_url() -> String {
-    String::from("https://servo.org")
-}
-
 fn default_trace_buffer() -> u64 {
     524288
 }
@@ -149,7 +237,7 @@ fn default_sleep() -> u64 {
 }
 
 fn default_bundle_name() -> String {
-    String::from("org.servo.servo")
+    String::from(SERVO_DEFAULT_BUNDLE)
 }
 
 fn default_commands() -> Option<Vec<String>> {
@@ -158,4 +246,159 @@ fn default_commands() -> Option<Vec<String>> {
 
 fn default_mitmproxy() -> bool {
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(argv: &[&str]) -> Args {
+        Args::try_parse_from(argv).expect("CLI should parse")
+    }
+
+    fn parse_run(argv: &[&str]) -> RunArgs {
+        parse(argv)
+            .run_args()
+            .cloned()
+            .expect("expected per-run arguments")
+    }
+
+    #[test]
+    fn per_run_is_optional_and_url_is_not_required() {
+        let args = parse(&["hitrace-bench"]);
+        assert!(args.run_args().is_none());
+
+        let run = parse_run(&["hitrace-bench", "per-run"]);
+        assert_eq!(run.url, None);
+        assert!(!run.no_servo_defaults);
+        assert_eq!(run.resolved_url(), Some(SERVO_DEFAULT_URL));
+        assert_eq!(run.result_label(), SERVO_DEFAULT_URL);
+        assert_eq!(run.bundle_name, SERVO_DEFAULT_BUNDLE);
+        assert!(run.forwarded_app_args().is_empty());
+    }
+
+    #[test]
+    fn explicit_url_still_works_for_servo() {
+        let run = parse_run(&[
+            "hitrace-bench",
+            "per-run",
+            "--url",
+            "https://example.com",
+            "--bundle-name",
+            "org.servo.servo",
+        ]);
+        assert_eq!(run.url.as_deref(), Some("https://example.com"));
+        assert_eq!(run.resolved_url(), Some("https://example.com"));
+        assert_eq!(run.result_label(), "https://example.com");
+        assert!(run.servo_defaults());
+    }
+
+    #[test]
+    fn no_servo_defaults_omits_homepage() {
+        let run = parse_run(&["hitrace-bench", "per-run", "--no-servo-defaults"]);
+        assert!(run.no_servo_defaults);
+        assert!(!run.servo_defaults());
+        assert_eq!(run.resolved_url(), None);
+        assert_eq!(run.result_label(), SERVO_DEFAULT_BUNDLE);
+    }
+
+    #[test]
+    fn empty_url_skips_ability_uri() {
+        let run = parse_run(&["hitrace-bench", "per-run", "--url", ""]);
+        assert_eq!(run.resolved_url(), None);
+    }
+
+    #[test]
+    fn app_arg_passthrough_is_repeatable() {
+        let run = parse_run(&[
+            "hitrace-bench",
+            "per-run",
+            "--no-servo-defaults",
+            "--bundle-name",
+            "com.example.app",
+            "--app-arg",
+            "--ps=--exit",
+            "--app-arg",
+            "--foo=bar",
+        ]);
+        assert_eq!(
+            run.forwarded_app_args(),
+            vec!["--ps=--exit".to_owned(), "--foo=bar".to_owned()]
+        );
+        assert_eq!(run.bundle_name, "com.example.app");
+        assert_eq!(run.resolved_url(), None);
+    }
+
+    #[test]
+    fn trailing_double_dash_args_are_forwarded() {
+        let run = parse_run(&[
+            "hitrace-bench",
+            "per-run",
+            "--url",
+            "https://servo.org",
+            "--",
+            "--ps=--exit",
+            "--psn=--pref=foo=true",
+        ]);
+        assert_eq!(
+            run.extra_args,
+            vec!["--ps=--exit".to_owned(), "--psn=--pref=foo=true".to_owned()]
+        );
+        assert_eq!(
+            run.forwarded_app_args(),
+            vec!["--ps=--exit".to_owned(), "--psn=--pref=foo=true".to_owned()]
+        );
+    }
+
+    #[test]
+    fn commands_app_args_and_trailing_args_are_merged() {
+        let run = parse_run(&[
+            "hitrace-bench",
+            "per-run",
+            "--commands",
+            "--legacy",
+            "--app-arg",
+            "--from-app-arg",
+            "--",
+            "--from-trailing",
+        ]);
+        assert_eq!(
+            run.forwarded_app_args(),
+            vec![
+                "--legacy".to_owned(),
+                "--from-app-arg".to_owned(),
+                "--from-trailing".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn json_commands_and_app_args_deserialize() {
+        let json = r#"{
+            "url": "https://www.google.com",
+            "commands": ["--ps=--tracing-filter", "info"],
+            "app_args": ["--ps=--exit"],
+            "no_servo_defaults": true
+        }"#;
+        let run: RunArgs = serde_json::from_str(json).expect("json should deserialize");
+        assert_eq!(run.url.as_deref(), Some("https://www.google.com"));
+        assert!(run.no_servo_defaults);
+        assert_eq!(run.resolved_url(), Some("https://www.google.com"));
+        assert_eq!(
+            run.forwarded_app_args(),
+            vec![
+                "--ps=--tracing-filter".to_owned(),
+                "info".to_owned(),
+                "--ps=--exit".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn json_without_url_keeps_servo_default_homepage() {
+        let run: RunArgs = serde_json::from_str("{}").expect("empty run_args should deserialize");
+        assert_eq!(run.url, None);
+        assert_eq!(run.resolved_url(), Some(SERVO_DEFAULT_URL));
+        assert!(run.servo_defaults());
+    }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -173,7 +173,7 @@ impl RunArgs {
     /// defaults supply `https://servo.org`.
     pub(crate) fn resolved_url(&self) -> Option<&str> {
         match self.url.as_deref() {
-            Some(url) if url.is_empty() => None,
+            Some("") => None,
             Some(url) => Some(url),
             None if self.servo_defaults() => Some(SERVO_DEFAULT_URL),
             None => None,

--- a/src/device.rs
+++ b/src/device.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 
-use crate::args::RunArgs;
+use crate::args::{RunArgs, servo_default_launch_flags, servo_mitmproxy_launch_flags};
 
 const PROXY_PORT: &str = "8080";
 
@@ -94,6 +94,34 @@ fn device_file_paths(file_name: &str, bundle_name: &str, is_rooted: bool) -> Dev
     }
 }
 
+/// Build `hdc aa start` arguments for the app under test.
+///
+/// `ability_uri` is the optional `-U` value (already rewritten for `file://` uploads).
+/// Servo-specific launch flags are included only when servo defaults are enabled.
+pub(crate) fn ability_start_args(run_args: &RunArgs, ability_uri: Option<&str>) -> Vec<String> {
+    let mut args = vec![
+        "shell".to_owned(),
+        "aa".to_owned(),
+        "start".to_owned(),
+        "-a".to_owned(),
+        "EntryAbility".to_owned(),
+        "-b".to_owned(),
+        run_args.bundle_name.clone(),
+    ];
+    if let Some(uri) = ability_uri {
+        args.push("-U".to_owned());
+        args.push(uri.to_owned());
+    }
+    if run_args.servo_defaults() {
+        args.extend(servo_default_launch_flags());
+    }
+    args.extend(run_args.forwarded_app_args());
+    if run_args.mitmproxy && run_args.servo_defaults() {
+        args.extend(servo_mitmproxy_launch_flags(PROXY_PORT));
+    }
+    args
+}
+
 /// Execute the hdc commands on the device.
 pub(crate) fn exec_hdc_commands(run_args: &RunArgs, is_rooted: bool) -> Result<PathBuf> {
     info!("Executing hdc commands");
@@ -104,26 +132,30 @@ pub(crate) fn exec_hdc_commands(run_args: &RunArgs, is_rooted: bool) -> Result<P
         .output()
         .context("Could not execute hdc")?;
 
-    let url = if run_args.url.contains("file:///") {
-        let device_file_path = device_file_paths(&run_args.url, &run_args.bundle_name, is_rooted);
+    let ability_uri = if let Some(url) = run_args.resolved_url() {
+        if url.contains("file:///") {
+            let device_file_path = device_file_paths(url, &run_args.bundle_name, is_rooted);
 
-        if is_rooted {
-            info!(
-                "Uploading to {} visible as {}",
-                device_file_path.on_device, device_file_path.in_app
-            );
-            Command::new(&hdc)
-                .args([
-                    "file",
-                    "send",
-                    &device_file_path.stem,
-                    &device_file_path.on_device,
-                ])
-                .output()?;
+            if is_rooted {
+                info!(
+                    "Uploading to {} visible as {}",
+                    device_file_path.on_device, device_file_path.in_app
+                );
+                Command::new(&hdc)
+                    .args([
+                        "file",
+                        "send",
+                        &device_file_path.stem,
+                        &device_file_path.on_device,
+                    ])
+                    .output()?;
+            }
+            Some(device_file_path.in_app)
+        } else {
+            Some(url.to_owned())
         }
-        device_file_path.in_app
     } else {
-        run_args.url.clone()
+        None
     };
 
     let _mitmproxy = if run_args.mitmproxy {
@@ -150,43 +182,9 @@ pub(crate) fn exec_hdc_commands(run_args: &RunArgs, is_rooted: bool) -> Result<P
         .output()?;
 
     // start the ability
-    let mut ability_start_arg = Command::new(&hdc);
-    ability_start_arg.args([
-        "shell",
-        "aa",
-        "start",
-        "-a",
-        "EntryAbility",
-        "-b",
-        &run_args.bundle_name,
-        "-U",
-        &url,
-        "--ps=--pref",
-        "js_disable_jit=true",
-        "--ps=--tracing-filter",
-        "trace",
-        "--psn=--pref=largest_contentful_paint_enabled=true",
-    ]);
-    if let Some(ref v) = run_args.commands {
-        for i in v {
-            ability_start_arg.arg(i);
-        }
-    }
-    if run_args.mitmproxy {
-        ability_start_arg.args([
-            format!(
-                "--psn=--pref=network_http_proxy_uri=http://127.0.0.1:{}",
-                PROXY_PORT
-            ),
-            format!(
-                "--psn=--pref=network_https_proxy_uri=http://127.0.0.1:{}",
-                PROXY_PORT
-            ),
-        ]);
-        ability_start_arg.arg("--psn=--ignore-certificate-errors");
-    }
-
-    ability_start_arg.output()?;
+    Command::new(&hdc)
+        .args(ability_start_args(run_args, ability_uri.as_deref()))
+        .output()?;
     // Getting app pid is a simple test if the app perhaps crashed during the benchmark / test.
     // Because teh app might finish rendering really fast, we need to be fast to check for the pid.
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -282,5 +280,97 @@ impl Drop for MitmProxy {
         if self.0.wait().is_err() {
             log::error!("Could not wait on killed process");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::args::{SERVO_DEFAULT_BUNDLE, SERVO_DEFAULT_URL, servo_default_launch_flags};
+
+    #[test]
+    fn servo_defaults_keep_homepage_and_servo_flags() {
+        let run_args = RunArgs::default();
+        let args = ability_start_args(&run_args, run_args.resolved_url());
+
+        assert_eq!(
+            &args[..8],
+            [
+                "shell",
+                "aa",
+                "start",
+                "-a",
+                "EntryAbility",
+                "-b",
+                SERVO_DEFAULT_BUNDLE,
+                "-U",
+            ]
+        );
+        assert_eq!(args[8], SERVO_DEFAULT_URL);
+        for flag in servo_default_launch_flags() {
+            assert!(
+                args.contains(&flag),
+                "servo default launch should include {flag}"
+            );
+        }
+    }
+
+    #[test]
+    fn generic_app_does_not_require_homepage_or_servo_flags() {
+        let run_args = RunArgs {
+            no_servo_defaults: true,
+            bundle_name: "com.example.app".to_owned(),
+            app_args: vec!["--foo".to_owned(), "bar".to_owned()],
+            extra_args: vec!["--baz".to_owned()],
+            ..RunArgs::default()
+        };
+        let args = ability_start_args(&run_args, run_args.resolved_url());
+
+        assert_eq!(
+            args,
+            vec![
+                "shell".to_owned(),
+                "aa".to_owned(),
+                "start".to_owned(),
+                "-a".to_owned(),
+                "EntryAbility".to_owned(),
+                "-b".to_owned(),
+                "com.example.app".to_owned(),
+                "--foo".to_owned(),
+                "bar".to_owned(),
+                "--baz".to_owned(),
+            ]
+        );
+        assert!(!args.contains(&"-U".to_owned()));
+        assert!(!args.iter().any(|arg| arg.contains("js_disable_jit")));
+        assert!(!args.iter().any(|arg| arg.contains("tracing-filter")));
+    }
+
+    #[test]
+    fn mitmproxy_flags_are_servo_specific() {
+        let servo = RunArgs {
+            mitmproxy: true,
+            ..RunArgs::default()
+        };
+        let servo_args = ability_start_args(&servo, servo.resolved_url());
+        assert!(
+            servo_args
+                .iter()
+                .any(|arg| arg.contains("network_http_proxy_uri"))
+        );
+
+        let generic = RunArgs {
+            no_servo_defaults: true,
+            mitmproxy: true,
+            app_args: vec!["--psn=--custom-proxy".to_owned()],
+            ..RunArgs::default()
+        };
+        let generic_args = ability_start_args(&generic, generic.resolved_url());
+        assert!(generic_args.contains(&"--psn=--custom-proxy".to_owned()));
+        assert!(
+            !generic_args
+                .iter()
+                .any(|arg| arg.contains("network_http_proxy_uri"))
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn print_differences(args: &RunArgs, results: RunResults) {
         "min".green(),
         "max".red(),
         args.tries,
-        args.url
+        args.result_label()
     );
     for (key, val) in results.filter_results.iter() {
         let avg_min_max = avg_min_max::<Duration, u16>(val);
@@ -103,7 +103,7 @@ fn run_runconfig_filters(
     let differences = filter::find_notable_differences(traces, &run_config.filters);
     for (original_key, value) in differences.into_iter() {
         let key = if run_config.args.run_file.is_some() {
-            format!("{}/{}", run_config.run_args.url, original_key)
+            format!("{}/{}", run_config.run_args.result_label(), original_key)
         } else {
             original_key.to_owned()
         };
@@ -145,7 +145,7 @@ pub(crate) fn run_runconfig(
     filter_errors: &mut FilterErrors,
     points: &mut PointResults,
 ) -> Result<()> {
-    info!("Running Test url {}", run_config.run_args.url);
+    info!("Running Test {}", run_config.run_args.result_label());
     for i in 1..run_config.run_args.tries + 1 {
         info!("Running test {i}");
         let traces = if let Some(ref file) = run_config.args.trace_file {
@@ -257,9 +257,10 @@ fn main() -> Result<()> {
                 },
             ];
 
+            let run_args = RunArgs::try_from(&args).unwrap_or_default();
             vec![RunConfig::new(
                 args.clone(),
-                RunArgs::default(),
+                run_args,
                 filters,
                 point_filters,
             )]

--- a/src/point_filters.rs
+++ b/src/point_filters.rs
@@ -167,13 +167,17 @@ impl PointFilter {
             .as_str()
             .parse()
             .expect("Could not parse value");
-        if url.contains(run_config.run_args.url.as_str()) {
+        let matches_url = match run_config.run_args.resolved_url() {
+            Some(expected) => url.contains(expected),
+            None => true,
+        };
+        if matches_url {
             let mut suffix = subsystem_path.split('/').skip(1).join("/");
             if !suffix.is_empty() {
                 suffix.insert(0, '/');
             }
             Some(Point {
-                name: run_config.run_args.url.to_owned()
+                name: run_config.run_args.result_label().to_owned()
                     + "/"
                     + self.name.as_str()
                     + suffix.as_str(),
@@ -207,7 +211,7 @@ impl PointFilter {
                 .parse()
                 .expect("Could not parse");
             Some(Point {
-                name: run_config.run_args.url.to_owned() + "/" + self.name.as_str(),
+                name: run_config.run_args.result_label().to_owned() + "/" + self.name.as_str(),
                 no_unit_conversion: self.no_unit_conversion,
                 trace: Some(trace),
                 point_type: PointType::Smaps(value),
@@ -233,7 +237,7 @@ impl PointFilter {
             .parse()
             .expect("Could not parse value");
         Some(Point {
-            name: run_config.run_args.url.to_owned() + "/" + self.name.as_str(),
+            name: run_config.run_args.result_label().to_owned() + "/" + self.name.as_str(),
             no_unit_conversion: self.no_unit_conversion,
             trace: Some(trace),
             point_type: PointType::MemoryReport(value),
@@ -260,7 +264,7 @@ impl PointFilter {
             .expect("Could not parse value");
         if case_name.contains(&self.match_str) {
             Some(Point {
-                name: run_config.run_args.url.to_owned() + "/",
+                name: run_config.run_args.result_label().to_owned() + "/",
                 no_unit_conversion: self.no_unit_conversion,
                 trace: Some(trace),
                 point_type: PointType::Testcase(value),
@@ -286,7 +290,7 @@ impl PointFilter {
             let lcp_values = parse_lcp_trace(key_values).expect("Could not parse LCP values");
             Some(vec![
                 Point {
-                    name: run_config.run_args.url.to_owned()
+                    name: run_config.run_args.result_label().to_owned()
                         + "/"
                         + self.name.as_str()
                         + "/paint_time",
@@ -295,7 +299,10 @@ impl PointFilter {
                     point_type: PointType::LargestContentfulPaint(lcp_values.paint_time),
                 },
                 Point {
-                    name: run_config.run_args.url.to_owned() + "/" + self.name.as_str() + "/area",
+                    name: run_config.run_args.result_label().to_owned()
+                        + "/"
+                        + self.name.as_str()
+                        + "/area",
                     no_unit_conversion: self.no_unit_conversion,
                     trace: Some(trace),
                     point_type: PointType::LargestContentfulPaint(lcp_values.area),
@@ -303,7 +310,10 @@ impl PointFilter {
             ])
         } else if filter_name == SERVO_FCP_STRING {
             Some(vec![Point {
-                name: run_config.run_args.url.to_owned() + "/" + self.name.as_str() + "/paint_time",
+                name: run_config.run_args.result_label().to_owned()
+                    + "/"
+                    + self.name.as_str()
+                    + "/paint_time",
                 no_unit_conversion: self.no_unit_conversion,
                 trace: Some(trace),
                 point_type: PointType::LargestContentfulPaint(

--- a/src/test.rs
+++ b/src/test.rs
@@ -40,7 +40,10 @@ fn parse_pointfilter_json() -> anyhow::Result<()> {
     let run_config: Vec<RunConfig> = read_run_file(&runs_json_path, &test_args)?;
     let run_config = &run_config[0];
 
-    assert_eq!(run_config.run_args.url, "https://www.google.com");
+    assert_eq!(
+        run_config.run_args.url.as_deref(),
+        Some("https://www.google.com")
+    );
     assert_eq!(run_config.run_args.tries, 5);
     assert_eq!(run_config.run_args.mitmproxy, true);
 


### PR DESCRIPTION
Fixes #1.

Stop treating servo-only flags (homepage) as required. Keep servo as the default/example, and add passthrough so app-specific arguments reach the app under test.

Host-checkable CLI/arg parsing. No device.

Signed-off-by: Tony Coder <407243179@qq.com>